### PR TITLE
feat: Enable pip caching to speed up execution

### DIFF
--- a/execution-code-eval/execute.py
+++ b/execution-code-eval/execute.py
@@ -15,12 +15,11 @@ args = parser.parse_args()
 
 pred_dir = args.prediction_dir
 save_dir = args.execution_dir
-pip_cache_dir = os.path.join(os.getcwd(), "pip_cache")
 
-if not os.path.exists(pip_cache_dir):
-    os.makedirs(pip_cache_dir)
 if not os.path.exists(save_dir):
     os.makedirs(save_dir)
+
+pip_cache_vol = "repoexec_pip_cache_vol"
 
 data = datasets.load_dataset("Fsoft-AIC/RepoExec")
 data = data[args.subset]
@@ -39,5 +38,5 @@ for task_id in range(len(data)):
     -v {repo_dir}:/input:ro \
     -v {repo_dir}/data_with_test_case:/output:ro \
     -v {repo_dir}/{project}/:/package:ro \
-    -v {pip_cache_dir}:/root/.cache/pip \
+    -v {pip_cache_vol}:/root/.cache/pip \
     codeeval-runner --task_id {task_id} --problem_file /pred_dir/processed_generations.json --rs_dir /rs_dir --timeout 120")

--- a/execution-code-eval/execute.py
+++ b/execution-code-eval/execute.py
@@ -38,5 +38,6 @@ for task_id in range(len(data)):
     -v {repo_dir}:/input:ro \
     -v {repo_dir}/data_with_test_case:/output:ro \
     -v {repo_dir}/{project}/:/package:ro \
-    -v {pip_cache_vol}:/root/.cache/pip \
+    -v {pip_cache_vol}:/tmp/pip_cache \
+    -e PIP_CACHE_DIR=/tmp/pip_cache \
     codeeval-runner --task_id {task_id} --problem_file /pred_dir/processed_generations.json --rs_dir /rs_dir --timeout 120")

--- a/execution-code-eval/execute.py
+++ b/execution-code-eval/execute.py
@@ -15,7 +15,10 @@ args = parser.parse_args()
 
 pred_dir = args.prediction_dir
 save_dir = args.execution_dir
+pip_cache_dir = os.path.join(os.getcwd(), "pip_cache")
 
+if not os.path.exists(pip_cache_dir):
+    os.makedirs(pip_cache_dir)
 if not os.path.exists(save_dir):
     os.makedirs(save_dir)
 
@@ -36,4 +39,5 @@ for task_id in range(len(data)):
     -v {repo_dir}:/input:ro \
     -v {repo_dir}/data_with_test_case:/output:ro \
     -v {repo_dir}/{project}/:/package:ro \
+    -v {pip_cache_dir}:/root/.cache/pip \
     codeeval-runner --task_id {task_id} --problem_file /pred_dir/processed_generations.json --rs_dir /rs_dir --timeout 120")


### PR DESCRIPTION
## Description

Currently, `execute.py` launches a fresh ephemeral container (--rm) for each task. As a result, pip install rebuilds wheels from source for dependencies (e.g., numpy, grpcio) every single time. This compilation step dominates the execution time, making the evaluation extremely slow.

This PR mounts a local directory to `/tmp/pip_cache` inside the container to persist built wheels across tasks.

## Impact

- Performance: Significantly reduces the installation time for subsequent tasks by reusing built wheels.
- Safety: Environment isolation is preserved. Only build artifacts (wheels) are shared, while installed packages (site-packages) remain isolated per container.
