### PR TITLE
fix: Upgrade pip to resolve dependency backtracking

### DIFF
--- a/execution-code-eval/Dockerfile
+++ b/execution-code-eval/Dockerfile
@@ -71,6 +71,7 @@ RUN apt-get update \
          tk \
          python3-tk
 
+RUN pip install --upgrade pip
 RUN pip install pandas tree-sitter pytest pytest-cov pytest-csv pytest-json coverage datasets timeout_decorator autoimport codetext jsonlines beautifulsoup4
 # ADD ./test-apps /pynguin/test-apps
 ADD human-eval /codegendata/human-eval

--- a/execution-code-eval/human-eval/setup.py
+++ b/execution-code-eval/human-eval/setup.py
@@ -19,7 +19,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "evaluate_functional_correctness = human_eval.evaluate_functional_correctness",
+            "evaluate_functional_correctness = human_eval.evaluate_functional_correctness:main",
         ]
     }
 )


### PR DESCRIPTION
## Problem
When building the docker image and running `execute.py`, the process hangs because of dependency resolution for `tornado` project.

The `execute` stage in `execution-code-eval/Dockerfile` uses the default pip version (v21.2.4) from the base image `python:3.10.2-slim-bullseye`.
This old version struggles with dependency resolution (backtracking) for complex projects, causing it to fetch incompatible ancient versions (e.g., `docutils 0.5` from 2009), leading to timeouts.

## Solution

I solved this problem by using a modern dependency resolver. Upgrading pip in docker container to a modern version helped well.

I had to update the `entry_points` definition in `execution-code-eval/human-eval/setup.py` to include the `:main` suffix, complying with modern pip.

## Verification
I have successfully run the full benchmark on all 355 tasks in the `full_context` subset with these changes. 
